### PR TITLE
Enable config json

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You can have multiple websites registered, each having their own configuration f
 
 A minimal website configuration file looks like this:
 
-```
+```json
 {   
   "name": "Hokus Website", /* your website friendly name */
   "key": "hokus-website", /* your website unique key */
@@ -74,6 +74,21 @@ A minimal website configuration file looks like this:
 
 Note that your website configuration can be a JSON, YAML or TOML file.
 
+### Hokus Configuration File
+
+An optional configuration file can be stored in your *home/username/Hokus*
+folder. When *config.json* is found hokus will read the settings at startup.
+
+It looks like this:
+
+```json
+{
+  "debugEnabled": true,
+  "cookbookEnabled": true,
+  "siteManagementEnabled": true
+}
+```
+
 ### Workspace Configuration File
 
 All the UI configurations and bindings are set in the workspace configuration file.
@@ -86,7 +101,7 @@ Keep in mind:
 
 For a minimal configuration file, see the default workspace configuration (which is auto created when you open a workspace without configuration), slightly changed:
 
-```
+```json
 {
   "hugover": "0.35",
   "serve":[
@@ -169,6 +184,10 @@ Some components have a "field" or "fields" property, allowing for nesting and co
 To see the components in action, you can access our [Forms Cookbook](http://formscookbook.hokus.io.s3-website-us-east-1.amazonaws.com/). For quick reference. _\(the Forms Cookbook is also included in the desktop app.\)_
 
 You can also refer to the source code to see all available properties for each component type.
+
+## Global configuration
+
+
 
 ### More Concepts
 

--- a/src-main/configuration-data-provider.js
+++ b/src-main/configuration-data-provider.js
@@ -107,7 +107,7 @@ function get(callback/*: (err: ?Error, data: Configurations | EmptyConfiguration
             let global = formatProvider.parse(strData);
             global = {
                 debugEnabled: global.debugEnabled == null ? GLOBAL_DEFAULTS.debugEnabled : global.debugEnabled===true, //default false
-                cookbookEnabled: global.cookbookEnabled == null ? GLOBAL_DEFAULTS.cookbookEnabled : global.debugEnabled===true, //default true
+                cookbookEnabled: global.cookbookEnabled == null ? GLOBAL_DEFAULTS.cookbookEnabled : global.cookbookEnabled===true, //default true
                 siteManagementEnabled: global.siteManagementEnabled == null ? GLOBAL_DEFAULTS.siteManagementEnabled : global.siteManagementEnabled===true
             }
             configurations.global = global;

--- a/src-main/electron.js
+++ b/src-main/electron.js
@@ -10,6 +10,7 @@ unhandled();
 
 // Module to control application life.
 const app = electron.app
+const Menu = electron.Menu
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -35,10 +36,130 @@ function createMainWindow () {
   contextMenu(mainWindow);
 }
 
+function createMainMenu(){
+  // iconst { app, Menu } = require('electron')
+
+  const isMac = process.platform === 'darwin'
+
+  const template = [
+    // { role: 'appMenu' }
+    ...(isMac ? [{
+      label: app.name,
+      submenu: [
+        { role: 'about' },
+        { type: 'separator' },
+        { role: 'services' },
+        { type: 'separator' },
+        { role: 'hide' },
+        { role: 'hideothers' },
+        { role: 'unhide' },
+        { type: 'separator' },
+        { role: 'quit' }
+      ]
+    }] : []),
+    // { role: 'fileMenu' }
+    {
+      label: 'File',
+      submenu: [
+        isMac ? { role: 'close' } : { role: 'quit' }
+      ]
+    },
+    // { role: 'editMenu' }
+    {
+      label: 'Edit',
+      submenu: [
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' },
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        ...(isMac ? [
+          { role: 'pasteAndMatchStyle' },
+          { role: 'delete' },
+          { role: 'selectAll' },
+          { type: 'separator' },
+          {
+            label: 'Speech',
+            submenu: [
+              { role: 'startspeaking' },
+              { role: 'stopspeaking' }
+            ]
+          }
+        ] : [
+          { role: 'delete' },
+          { type: 'separator' },
+          { role: 'selectAll' }
+        ])
+      ]
+    },
+    // { role: 'viewMenu' }
+    {
+      label: 'View',
+      submenu: [
+        { role: 'reload' },
+        {
+          label: 'Show Log Window',
+          click: async () => {
+            const { shell } = require('electron')
+            await shell.openExternal('https://lingewoud.nl')
+          }
+        },
+        { role: 'reload' },
+        { role: 'forcereload' },
+        { role: 'toggledevtools' },
+        { type: 'separator' },
+        { role: 'resetzoom' },
+        { role: 'zoomin' },
+        { role: 'zoomout' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' }
+      ]
+    },
+    // { role: 'windowMenu' }
+    {
+      label: 'Window',
+      submenu: [
+        { role: 'minimize' },
+        { role: 'zoom' },
+        ...(isMac ? [
+          { type: 'separator' },
+          { role: 'front' },
+          { type: 'separator' },
+          { role: 'window' }
+        ] : [
+          { role: 'close' }
+        ])
+      ]
+    },
+    {
+      role: 'help',
+      submenu: [
+        {
+          label: 'Learn More',
+          click: async () => {
+            const { shell } = require('electron')
+            await shell.openExternal('https://electronjs.org')
+          }
+        }
+      ]
+    }
+  ]
+
+  const menu = Menu.buildFromTemplate(template)
+  Menu.setApplicationMenu(menu)
+}
+
+
+
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-app.on('ready', createMainWindow)
+app.on('ready', function () {
+  createMainMenu();
+  createMainWindow();
+})
+
 
 // Quit when all windows are closed.
 app.on('window-all-closed', function () {

--- a/src-main/electron.js
+++ b/src-main/electron.js
@@ -10,7 +10,6 @@ unhandled();
 
 // Module to control application life.
 const app = electron.app
-const Menu = electron.Menu
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -36,130 +35,10 @@ function createMainWindow () {
   contextMenu(mainWindow);
 }
 
-function createMainMenu(){
-  // iconst { app, Menu } = require('electron')
-
-  const isMac = process.platform === 'darwin'
-
-  const template = [
-    // { role: 'appMenu' }
-    ...(isMac ? [{
-      label: app.name,
-      submenu: [
-        { role: 'about' },
-        { type: 'separator' },
-        { role: 'services' },
-        { type: 'separator' },
-        { role: 'hide' },
-        { role: 'hideothers' },
-        { role: 'unhide' },
-        { type: 'separator' },
-        { role: 'quit' }
-      ]
-    }] : []),
-    // { role: 'fileMenu' }
-    {
-      label: 'File',
-      submenu: [
-        isMac ? { role: 'close' } : { role: 'quit' }
-      ]
-    },
-    // { role: 'editMenu' }
-    {
-      label: 'Edit',
-      submenu: [
-        { role: 'undo' },
-        { role: 'redo' },
-        { type: 'separator' },
-        { role: 'cut' },
-        { role: 'copy' },
-        { role: 'paste' },
-        ...(isMac ? [
-          { role: 'pasteAndMatchStyle' },
-          { role: 'delete' },
-          { role: 'selectAll' },
-          { type: 'separator' },
-          {
-            label: 'Speech',
-            submenu: [
-              { role: 'startspeaking' },
-              { role: 'stopspeaking' }
-            ]
-          }
-        ] : [
-          { role: 'delete' },
-          { type: 'separator' },
-          { role: 'selectAll' }
-        ])
-      ]
-    },
-    // { role: 'viewMenu' }
-    {
-      label: 'View',
-      submenu: [
-        { role: 'reload' },
-        {
-          label: 'Show Log Window',
-          click: async () => {
-            const { shell } = require('electron')
-            await shell.openExternal('https://lingewoud.nl')
-          }
-        },
-        { role: 'reload' },
-        { role: 'forcereload' },
-        { role: 'toggledevtools' },
-        { type: 'separator' },
-        { role: 'resetzoom' },
-        { role: 'zoomin' },
-        { role: 'zoomout' },
-        { type: 'separator' },
-        { role: 'togglefullscreen' }
-      ]
-    },
-    // { role: 'windowMenu' }
-    {
-      label: 'Window',
-      submenu: [
-        { role: 'minimize' },
-        { role: 'zoom' },
-        ...(isMac ? [
-          { type: 'separator' },
-          { role: 'front' },
-          { type: 'separator' },
-          { role: 'window' }
-        ] : [
-          { role: 'close' }
-        ])
-      ]
-    },
-    {
-      role: 'help',
-      submenu: [
-        {
-          label: 'Learn More',
-          click: async () => {
-            const { shell } = require('electron')
-            await shell.openExternal('https://electronjs.org')
-          }
-        }
-      ]
-    }
-  ]
-
-  const menu = Menu.buildFromTemplate(template)
-  Menu.setApplicationMenu(menu)
-}
-
-
-
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
-app.on('ready', function () {
-  createMainMenu();
-  createMainWindow();
-})
-
+app.on('ready', createMainWindow)
 
 // Quit when all windows are closed.
 app.on('window-all-closed', function () {


### PR DESCRIPTION
I wanted to implement a global config when I stumbled upon the existing functionality.  I fixed some stuff en updated the README. 

- documentation about config.json
- fix read enableCookbooks config.json
- obey enableCookbooks in ExtraOptions in src/App.js

btw... I removed the Application Menu in the last commit to keep this PR clean.
